### PR TITLE
Added test to repo standard assign not work.

### DIFF
--- a/tests/binary_assign_static.phpt
+++ b/tests/binary_assign_static.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Standard assign to static property
+--SKIPIF--
+<?php if(!extension_loaded("operator")) print "skip"; ?>
+--FILE--
+<?php
+class foo {
+	static $value;
+}
+
+foo::$value = 1;
+var_dump(foo::$value);
+--EXPECT--
+int(1)


### PR DESCRIPTION
it was found while investigating https://bugs.php.net/bug.php?id=65278

some info from gdb and coredump

```
> gdb /opt/phpfarm/inst/php-5.4.16-debug/bin/php
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /opt/phpfarm/inst/php-5.4.16-debug/bin/php...done.
(gdb) run /home/maksim/projects/Remixjobs/Remixjobs/Remixjobs/app/console
Starting program: /opt/phpfarm/inst/php-5.4.16-debug/bin/php /home/maksim/projects/Remixjobs/Remixjobs/Remixjobs/app/console
warning: no loadable sections found in added symbol-file system-supplied DSO at 0x7ffff7ffa000

Program received signal SIGSEGV, Segmentation fault.
0x00000000008dc094 in _zend_is_inconsistent (ht=0x0, file=0xe7cf38 "/opt/phpfarm/src/php-5.4.16-debug/Zend/zend_hash.c", line=946)
    at /opt/phpfarm/src/php-5.4.16-debug/Zend/zend_hash.c:54
54      if (ht->inconsistent==HT_OK) {
(gdb) bt
#0  0x00000000008dc094 in _zend_is_inconsistent (ht=0x0, file=0xe7cf38 "/opt/phpfarm/src/php-5.4.16-debug/Zend/zend_hash.c", line=946)
    at /opt/phpfarm/src/php-5.4.16-debug/Zend/zend_hash.c:54
#1  0x00000000008ded38 in zend_hash_quick_find (ht=0x0, arKey=0x7ffff7eba398 "loader", nKeyLength=7, h=229473782970300, pData=0x7ffff7f92e70)
    at /opt/phpfarm/src/php-5.4.16-debug/Zend/zend_hash.c:946
#2  0x00007ffff667e12f in php_operator_zval_ptr (optype=16 '\020', node_op=0x7ffff666b900, should_free=0x7fffffffa3b0, 
    execute_data=0x7ffff7f92de0, silent=1 '\001') at /opt/phpfarm/pecl-php-operator/operator.c:93
#3  0x00007ffff667eabb in _php_operator_binary_assign_op (execute_data=0x7ffff7f92de0, methodname=0x7ffff6680687 "__assign", 
    methodname_len=8) at /opt/phpfarm/pecl-php-operator/operator.c:357
#4  0x00007ffff667f38f in php_operator_op_ZEND_ASSIGN (execute_data=0x7ffff7f92de0) at /opt/phpfarm/pecl-php-operator/operator.c:473
#5  0x0000000000906727 in execute (op_array=0x7ffff66657d0) at /opt/phpfarm/src/php-5.4.16-debug/Zend/zend_vm_execute.h:410
#6  0x00000000008ccd03 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /opt/phpfarm/src/php-5.4.16-debug/Zend/zend.c:1315
#7  0x000000000084309e in php_execute_script (primary_file=0x7fffffffc990) at /opt/phpfarm/src/php-5.4.16-debug/main/main.c:2494
#8  0x000000000096e118 in do_cli (argc=2, argv=0x7fffffffdde8) at /opt/phpfarm/src/php-5.4.16-debug/sapi/cli/php_cli.c:988
#9  0x000000000096f2d9 in main (argc=2, argv=0x7fffffffdde8) at /opt/phpfarm/src/php-5.4.16-debug/sapi/cli/php_cli.c:1364
```
