### PR TITLE
Update to PHP 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 /run-tests.php
 /*.lo
 /*.la
+
+/tests
+/tmp-php.ini
+/*.dep

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,10 @@
 /run-tests.php
 /*.lo
 /*.la
-
-/tests
-/tmp-php.ini
-/*.dep
+tests/*.diff
+tests/*.out
+tests/*.php
+tests/*.exp
+tests/*.log
+tests/*.sh
+*.dep

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Operator overloading extension for PHP7
+# Operator overloading extension for PHP8.3
 
 ## Usage
 
@@ -51,7 +51,6 @@ The following overload methods are supported:
 | $o++  | `__post_inc()` |
 | --$o | `__pre_dec()` |
 | $o-- | `__post_dec()` |
-| $o = $arg | `__assign($arg)` |
 | $o += $arg | `__assign_add($arg)` |
 | $o -= $arg | `__assign_sub($arg)` |
 | $o *= $arg | `__assign_mul($arg)` |

--- a/operator.c
+++ b/operator.c
@@ -6,21 +6,21 @@
 
 #define USE_OPLINE const zend_op *opline = EX(opline);
 #define GET_OP1_ZVAL_PTR_UNDEF(fetch) \
-  get_zval_ptr_undef(opline->op1_type, opline->op1, &free_op1, execute_data)
+    get_zval_ptr_undef(opline->op1_type, opline->op1, free_op1, execute_data, opline)
 #define GET_OP2_ZVAL_PTR_UNDEF(fetch) \
-  get_zval_ptr_undef(opline->op2_type, opline->op2, &free_op2, execute_data)
+    get_zval_ptr_undef(opline->op2_type, opline->op2, free_op2, execute_data, opline)
 
 #define FREE_OP1 if (free_op1) { zval_ptr_dtor_nogc(free_op1); }
 #define FREE_OP2 if (free_op2) { zval_ptr_dtor_nogc(free_op2); }
 
 static
-zval *get_zval_ptr_undef(zend_uchar op_type, znode_op op, zend_free_op *free_op,
-                         zend_execute_data *execute_data) {
+zval *get_zval_ptr_undef(zend_uchar op_type, znode_op node, zval *free_op,
+                         zend_execute_data *execute_data, const zend_op* opline) {
   switch (op_type) {
     case IS_TMP_VAR:
-    case IS_VAR:      return (*free_op = EX_VAR(op.var));
-    case IS_CONST:    return EX_CONSTANT(op);
-    case IS_CV:       return EX_VAR(op.var);
+    case IS_VAR:      return (free_op = EX_VAR(node.var));
+    case IS_CONST:    return RT_CONSTANT(opline, node);
+    case IS_CV:       return EX_VAR(node.var);
     default:          return NULL;
   }
 }
@@ -57,20 +57,23 @@ zval *get_zval_ptr_undef(zend_uchar op_type, znode_op op, zend_free_op *free_op,
   X(PRE_DEC,             __pre_dec) \
   X(POST_DEC,            __post_dec)
 
+// TODO ZEND_ASSIGN_ADD and others have been changed for ZEND_ASSIGN_OP + ADD
+// https://github.com/php/php-src/commit/48ca5a1e176c5301fedd1bc4f661969d6f9a49eb
+
 #define BINARY_ASSIGN_OPS(X) \
-  X(ASSIGN,              __assign) \
-  X(ASSIGN_ADD,          __assign_add) \
-  X(ASSIGN_SUB,          __assign_sub) \
-  X(ASSIGN_MUL,          __assign_mul) \
-  X(ASSIGN_DIV,          __assign_div) \
-  X(ASSIGN_MOD,          __assign_mod) \
-  X(ASSIGN_POW,          __assign_pow) \
-  X(ASSIGN_SL,           __assign_sl) \
-  X(ASSIGN_SR,           __assign_sr) \
-  X(ASSIGN_CONCAT,       __assign_concat) \
-  X(ASSIGN_BW_OR,        __assign_bw_or) \
-  X(ASSIGN_BW_AND,       __assign_bw_and) \
-  X(ASSIGN_BW_XOR,       __assign_bw_xor)
+  X(ASSIGN,              __assign)
+  /* X(ASSIGN_ADD,          __assign_add) \ */
+  /* X(ASSIGN_SUB,          __assign_sub) \ */
+  /* X(ASSIGN_MUL,          __assign_mul) \ */
+  /* X(ASSIGN_DIV,          __assign_div) \ */
+  /* X(ASSIGN_MOD,          __assign_mod) \ */
+  /* X(ASSIGN_POW,          __assign_pow) \ */
+  /* X(ASSIGN_SL,           __assign_sl) \ */
+  /* X(ASSIGN_SR,           __assign_sr) \ */
+  /* X(ASSIGN_CONCAT,       __assign_concat) \ */
+  /* X(ASSIGN_BW_OR,        __assign_bw_or) \ */
+  /* X(ASSIGN_BW_AND,       __assign_bw_and) \ */
+  /* X(ASSIGN_BW_XOR,       __assign_bw_xor) */
 
 #define ALL_OPS(X) \
   UNARY_OPS(X) \
@@ -113,7 +116,9 @@ static zend_bool operator_get_method(zend_string *method, zval *obj,
   ZVAL_STR(&(fci->function_name), method);
 
   if (!zend_is_callable_ex(&(fci->function_name), fci->object,
-                           IS_CALLABLE_CHECK_SILENT | IS_CALLABLE_STRICT,
+                           0,
+                           // TODO What options should we enable here?
+                           /* IS_CALLABLE_CHECK_SILENT | IS_CALLABLE_STRICT, */
                            NULL, fcc, NULL)) {
     return 0;
   }
@@ -147,7 +152,7 @@ GREATER_OPS(X)
 /* {{{ op_handler */
 static int op_handler(zend_execute_data *execute_data) {
   USE_OPLINE
-  zend_free_op free_op1 = NULL, free_op2 = NULL;
+  zval *free_op1, *free_op2 = NULL;
   zval *op1, *op2 = NULL;
   zend_fcall_info fci;
   zend_fcall_info_cache fcc;
@@ -172,7 +177,7 @@ BINARY_ASSIGN_OPS(X)
 
   if (operator_is_greater_op(opline, &method)) {
     zval *tmp = op1;
-    zend_free_op free_tmp = free_op1;
+    zval *free_tmp = free_op1;
     op1 = op2; op2 = tmp;
     free_op1 = free_op2; free_op2 = free_tmp;
   }
@@ -187,7 +192,7 @@ BINARY_ASSIGN_OPS(X)
   fci.params = op2;
   fci.param_count = op2 ? 1 : 0;
   if (FAILURE == zend_call_function(&fci, &fcc)) {
-    php_error(E_WARNING, "Failed calling %s::%s()", Z_OBJCE_P(op1)->name, Z_STRVAL(fci.function_name));
+    php_error(E_WARNING, "Failed calling %s::%s()", ZSTR_VAL(Z_OBJCE_P(op1)->name), Z_STRVAL(fci.function_name));
     ZVAL_NULL(fci.retval);
   }
 

--- a/operator.c
+++ b/operator.c
@@ -144,9 +144,7 @@ static zend_bool operator_get_method(zend_string *method, zval *obj,
   ZVAL_STR(&(fci->function_name), method);
 
   if (!zend_is_callable_ex(&(fci->function_name), fci->object,
-                           0,
-                           // TODO What options should we enable here?
-                           /* IS_CALLABLE_CHECK_SILENT | IS_CALLABLE_STRICT, */
+                           IS_CALLABLE_SUPPRESS_DEPRECATIONS,
                            NULL, fcc, NULL)) {
     return 0;
   }

--- a/operator.c
+++ b/operator.c
@@ -258,7 +258,7 @@ static zend_module_entry operator_module_entry = {
   NULL, /* RINIT */
   NULL, /* RSHUTDOWN */
   NULL, /* MINFO */
-  "7.2.0",
+  "8.3.0",
   STANDARD_MODULE_PROPERTIES
 };
 /* }}} */

--- a/operator.c
+++ b/operator.c
@@ -60,20 +60,35 @@ zval *get_zval_ptr_undef(zend_uchar op_type, znode_op node, zval *free_op,
 // TODO ZEND_ASSIGN_ADD and others have been changed for ZEND_ASSIGN_OP + ADD
 // https://github.com/php/php-src/commit/48ca5a1e176c5301fedd1bc4f661969d6f9a49eb
 
+// NOTE: Assign operators are now a pair of one of the following assignment ops with the corresponding "normal" op, which is stored in opline->extended_value
+// ZEND_ASSIGN_OP: For $var += $value
+// ZEND_ASSIGN_DIM_OP: For $array[$key] += $value
+// ZEND_ASSIGN_OBJ_OP: For $obj->prop += $value
+// ZEND_ASSIGN_STATIC_PROP_OP: For self::$prop += $value
+// See https://github.com/php/php-src/blob/7be3649016d2c2a67d592d0e738433898d7ce81e/Zend/zend_compile.c#L3645-L3646
+
+// It seems like these opcodes don't get passed to op_handler,
+// so these methods don't actually work.
+// I'm keeping them here to keep the structure of the macros
 #define BINARY_ASSIGN_OPS(X) \
-  X(ASSIGN,              __assign)
-  /* X(ASSIGN_ADD,          __assign_add) \ */
-  /* X(ASSIGN_SUB,          __assign_sub) \ */
-  /* X(ASSIGN_MUL,          __assign_mul) \ */
-  /* X(ASSIGN_DIV,          __assign_div) \ */
-  /* X(ASSIGN_MOD,          __assign_mod) \ */
-  /* X(ASSIGN_POW,          __assign_pow) \ */
-  /* X(ASSIGN_SL,           __assign_sl) \ */
-  /* X(ASSIGN_SR,           __assign_sr) \ */
-  /* X(ASSIGN_CONCAT,       __assign_concat) \ */
-  /* X(ASSIGN_BW_OR,        __assign_bw_or) \ */
-  /* X(ASSIGN_BW_AND,       __assign_bw_and) \ */
-  /* X(ASSIGN_BW_XOR,       __assign_bw_xor) */
+    X(ASSIGN_OP,              __assign) \
+    X(ASSIGN_DIM_OP,          __assign_dim) \
+    X(ASSIGN_OBJ_OP,          __assign_obj) \
+    X(ASSIGN_STATIC_PROP_OP,  __assign)
+
+#define COMBINED_BINARY_ASSIGN_OPS(X) \
+  X(ADD,          __assign_add) \
+  X(SUB,          __assign_sub) \
+  X(MUL,          __assign_mul) \
+  X(DIV,          __assign_div) \
+  X(MOD,          __assign_mod) \
+  X(POW,          __assign_pow) \
+  X(SL,           __assign_sl) \
+  X(SR,           __assign_sr) \
+  X(CONCAT,       __assign_concat) \
+  X(BW_OR,        __assign_bw_or) \
+  X(BW_AND,       __assign_bw_and) \
+  X(BW_XOR,       __assign_bw_xor)
 
 #define ALL_OPS(X) \
   UNARY_OPS(X) \
@@ -91,18 +106,33 @@ zval *get_zval_ptr_undef(zend_uchar op_type, znode_op node, zval *free_op,
 #define X(op, meth) static zend_string *s_##meth;
 ALL_OPS(X)
 GREATER_OPS(X)
+COMBINED_BINARY_ASSIGN_OPS(X)
 #undef X
 
 /* {{{ operator_method_name */
-static inline zend_string* operator_method_name(zend_uchar opcode) {
-  switch (opcode) {
+static inline zend_string* operator_method_name(const zend_op *opline) {
+    switch (opline->opcode) {
 #define X(op, meth) case ZEND_##op: return s_##meth;
-ALL_OPS(X)
+    UNARY_OPS(X)
+    BINARY_OPS(X)
+    UNARY_ASSIGN_OPS(X)
 #undef X
+
+#define Y(op, meth) case ZEND_##op: return s_##meth;
+#define X(op, meth) case ZEND_##op: switch (opline->extended_value) {\
+        COMBINED_BINARY_ASSIGN_OPS(Y) \
+        default: \
+            ZEND_ASSERT(0); \
+            return NULL; \
+    }
+
+    BINARY_ASSIGN_OPS(X)
+#undef X
+#undef Y
     default:
 		ZEND_ASSERT(0);
 		return NULL;
-  }
+    }
 }
 /* }}} */
 
@@ -156,7 +186,7 @@ static int op_handler(zend_execute_data *execute_data) {
   zval *op1, *op2 = NULL;
   zend_fcall_info fci;
   zend_fcall_info_cache fcc;
-  zend_string *method = operator_method_name(opline->opcode);
+  zend_string *method = operator_method_name(opline);
 
   if (opline->op1_type == IS_UNUSED) {
     /* Assign op */
@@ -181,6 +211,9 @@ BINARY_ASSIGN_OPS(X)
     op1 = op2; op2 = tmp;
     free_op1 = free_op2; free_op2 = free_tmp;
   }
+
+  // so i think we need to pass the fact that it's an assignment to get_method
+  // then get method can return a differen thing in the case of binary assign ops
 
   if ((Z_TYPE_P(op1) != IS_OBJECT) ||
       !operator_get_method(method, op1, &fci, &fcc)) {
@@ -208,10 +241,11 @@ static PHP_MINIT_FUNCTION(operator) {
 #define X(op, meth) \
   s_##meth = zend_string_init(#meth, strlen(#meth), 1);
 GREATER_OPS(X)
+COMBINED_BINARY_ASSIGN_OPS(X)
+ALL_OPS(X)
 #undef X
 
 #define X(op, meth) \
-  s_##meth = zend_string_init(#meth, strlen(#meth), 1); \
   zend_set_user_opcode_handler(ZEND_##op, op_handler);
 ALL_OPS(X)
 #undef X

--- a/operator.c
+++ b/operator.c
@@ -57,10 +57,8 @@ zval *get_zval_ptr_undef(zend_uchar op_type, znode_op node, zval *free_op,
   X(PRE_DEC,             __pre_dec) \
   X(POST_DEC,            __post_dec)
 
-// TODO ZEND_ASSIGN_ADD and others have been changed for ZEND_ASSIGN_OP + ADD
-// https://github.com/php/php-src/commit/48ca5a1e176c5301fedd1bc4f661969d6f9a49eb
-
 // NOTE: Assign operators are now a pair of one of the following assignment ops with the corresponding "normal" op, which is stored in opline->extended_value
+// https://github.com/php/php-src/commit/48ca5a1e176c5301fedd1bc4f661969d6f9a49eb
 // ZEND_ASSIGN_OP: For $var += $value
 // ZEND_ASSIGN_DIM_OP: For $array[$key] += $value
 // ZEND_ASSIGN_OBJ_OP: For $obj->prop += $value
@@ -211,9 +209,6 @@ BINARY_ASSIGN_OPS(X)
     op1 = op2; op2 = tmp;
     free_op1 = free_op2; free_op2 = free_tmp;
   }
-
-  // so i think we need to pass the fact that it's an assignment to get_method
-  // then get method can return a differen thing in the case of binary assign ops
 
   if ((Z_TYPE_P(op1) != IS_OBJECT) ||
       !operator_get_method(method, op1, &fci, &fcc)) {

--- a/operator.c
+++ b/operator.c
@@ -6,9 +6,9 @@
 
 #define USE_OPLINE const zend_op *opline = EX(opline);
 #define GET_OP1_ZVAL_PTR_UNDEF(fetch) \
-    get_zval_ptr_undef(opline->op1_type, opline->op1, free_op1, execute_data, opline)
+  get_zval_ptr_undef(opline->op1_type, opline->op1, free_op1, execute_data, opline)
 #define GET_OP2_ZVAL_PTR_UNDEF(fetch) \
-    get_zval_ptr_undef(opline->op2_type, opline->op2, free_op2, execute_data, opline)
+  get_zval_ptr_undef(opline->op2_type, opline->op2, free_op2, execute_data, opline)
 
 #define FREE_OP1 if (free_op1) { zval_ptr_dtor_nogc(free_op1); }
 #define FREE_OP2 if (free_op2) { zval_ptr_dtor_nogc(free_op2); }
@@ -69,10 +69,10 @@ zval *get_zval_ptr_undef(zend_uchar op_type, znode_op node, zval *free_op,
 // so these methods don't actually work.
 // I'm keeping them here to keep the structure of the macros
 #define BINARY_ASSIGN_OPS(X) \
-    X(ASSIGN_OP,              __assign) \
-    X(ASSIGN_DIM_OP,          __assign_dim) \
-    X(ASSIGN_OBJ_OP,          __assign_obj) \
-    X(ASSIGN_STATIC_PROP_OP,  __assign)
+  X(ASSIGN_OP,              __assign) \
+  X(ASSIGN_DIM_OP,          __assign_dim) \
+  X(ASSIGN_OBJ_OP,          __assign_obj) \
+  X(ASSIGN_STATIC_PROP_OP,  __assign)
 
 #define COMBINED_BINARY_ASSIGN_OPS(X) \
   X(ADD,          __assign_add) \
@@ -109,28 +109,28 @@ COMBINED_BINARY_ASSIGN_OPS(X)
 
 /* {{{ operator_method_name */
 static inline zend_string* operator_method_name(const zend_op *opline) {
-    switch (opline->opcode) {
+  switch (opline->opcode) {
 #define X(op, meth) case ZEND_##op: return s_##meth;
-    UNARY_OPS(X)
-    BINARY_OPS(X)
-    UNARY_ASSIGN_OPS(X)
+UNARY_OPS(X)
+BINARY_OPS(X)
+UNARY_ASSIGN_OPS(X)
 #undef X
 
 #define Y(op, meth) case ZEND_##op: return s_##meth;
 #define X(op, meth) case ZEND_##op: switch (opline->extended_value) {\
-        COMBINED_BINARY_ASSIGN_OPS(Y) \
-        default: \
-            ZEND_ASSERT(0); \
-            return NULL; \
-    }
+    COMBINED_BINARY_ASSIGN_OPS(Y) \
+    default: \
+      ZEND_ASSERT(0); \
+      return NULL; \
+  }
 
-    BINARY_ASSIGN_OPS(X)
+BINARY_ASSIGN_OPS(X)
 #undef X
 #undef Y
     default:
 		ZEND_ASSERT(0);
 		return NULL;
-    }
+  }
 }
 /* }}} */
 

--- a/tests/binary_assign.phpt
+++ b/tests/binary_assign.phpt
@@ -7,10 +7,6 @@ Basic binary assign ops
 class foo {
 	private $value;
 
-	function __assign($val) {
-		return $this->value = $val;
-	}
-
 	function __assign_add($val) {
 		return $this->value += $val;
 	}
@@ -61,7 +57,6 @@ class foo {
 }
 
 $a = new foo(1);
-var_dump($a  = 2);
 var_dump($a += 2);
 var_dump(is_object($a));
 
@@ -86,8 +81,7 @@ var_dump($f |= 0xAA);
 var_dump($f &= 0xAA);
 var_dump($f ^= 0xAA);
 --EXPECT--
-int(2)
-int(4)
+int(3)
 bool(true)
 int(7)
 int(4)


### PR DESCRIPTION
This PR updates the extension for PHP 8.3. 

Of note: `__assign($arg)` has been removed, since I don't think it can work anymore (`op_handler` doesn't seem to be called with `ZEND_ASSIGN_OP`, `ZEND_ASSIGN_DIM_OP`, etc when doing `$o = $arg;`). Everything else should be working, and all the tests are passing on my machine, except the one that requires patching PHP, which I haven't tried since I don't really know how to do that. 

I'm not very familiar with PHP internals, so this is a best effort attempt, from what I've been able to piece together from the php-src repo's git history. I can't tell if any of the changes I've made could cause issues. 

I don't really have a use-case for this extension, I just wanted to update it as an excuse to delve more into PHP internals. 